### PR TITLE
Chapter 6 - Rejecting Invalid Subscribers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ tracing-log = "0.1"
 secrecy = { version = "0.8", features = ["serde"] }
 tracing-actix-web = "0.6"
 serde-aux = "3"
+unicode-segmentation = "1"
+validator = "0.14"
 
 # Using table-like toml syntax to avoid a super-long line!
 [dependencies.sqlx]
@@ -52,5 +54,9 @@ features = [
 [dev-dependencies]
 # Dev deps are used exclusively when running tests or examples.
 # They don't get included in the final application binary!
+claim = "0.5"
 once_cell = "1"
 reqwest = "0.11"
+fake = "~2.3"
+quickcheck = "0.9.2"
+quickcheck_macros = "0.9.1"

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,0 +1,7 @@
+mod subscriber_name;
+mod subscriber_email;
+mod new_subscriber;
+
+pub use subscriber_name::SubscriberName;
+pub use subscriber_email::SubscriberEmail;
+pub use new_subscriber::NewSubscriber;

--- a/src/domain/new_subscriber.rs
+++ b/src/domain/new_subscriber.rs
@@ -1,0 +1,7 @@
+use crate::domain::SubscriberName;
+use crate::domain::SubscriberEmail;
+
+pub struct NewSubscriber {
+    pub email: SubscriberEmail,
+    pub name: SubscriberName,
+}

--- a/src/domain/subscriber_email.rs
+++ b/src/domain/subscriber_email.rs
@@ -1,0 +1,69 @@
+use validator::validate_email;
+
+#[derive(Debug)]
+pub struct SubscriberEmail(String);
+
+impl SubscriberEmail {
+    pub fn parse(s: String) -> Result<SubscriberEmail, String> {
+        if validate_email(&s) {
+            Ok(Self(s))
+        } else {
+            Err(format!("{} is not a valid subscriber email.", s))
+        }
+    }
+}
+
+impl AsRef<str> for SubscriberEmail {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    // We have removed the `assert_ok` import.
+    use claim::assert_err;
+
+    // We are importing the `SafeEmail` faker!
+    // We also need the `Fake` trait to get acces to the
+    // `.fake` method on `SafeEmail`.
+    use fake::faker::internet::en::SafeEmail;
+    use fake::Fake;
+
+    use super::SubscriberEmail;
+
+    #[test]
+    fn empty_string_is_rejected() {
+        let email = "".to_string();
+        assert_err!(SubscriberEmail::parse(email));
+    }
+
+    #[test]
+    fn email_missing_at_symbol_is_rejected() {
+        let email = "ursuladomain.com".to_string();
+        assert_err!(SubscriberEmail::parse(email));
+    }
+
+    #[test]
+    fn email_missing_subject_is_rejected() {
+        let email = "@domain.com".to_string();
+        assert_err!(SubscriberEmail::parse(email));
+    }
+
+    // Both `Clone` and `Debug` are required by `quickcheck`
+    #[derive(Debug, Clone)]
+    struct ValidEmailFixture(pub String);
+
+    impl quickcheck::Arbitrary for ValidEmailFixture {
+        fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+            let email = SafeEmail().fake_with_rng(g);
+            Self(email)
+        }
+    }
+
+    #[quickcheck_macros::quickcheck]
+    fn valid_emails_are_parsed_successfully(valid_email: ValidEmailFixture) -> bool {
+        SubscriberEmail::parse(valid_email.0).is_ok()
+    }
+}

--- a/src/domain/subscriber_name.rs
+++ b/src/domain/subscriber_name.rs
@@ -1,0 +1,86 @@
+use unicode_segmentation::UnicodeSegmentation;
+
+#[derive(Debug)]
+pub struct SubscriberName(String);
+
+impl SubscriberName {
+    // The ONLY way to get a SubscriberName is through `parse()`, which validates our input.
+    // Therefore, if we have a SubscriberName, we know it has been validated.
+    pub fn parse(s: String) -> Result<SubscriberName, String> {
+        // `.trim()` returns a view over the input `s` without trailing whitespace-like characters.
+        // `.is_empty()` checks if the view contains any character.
+        let is_empty_or_whitespace = s.trim().is_empty();
+
+        // A grapheme is defined by the Unicode standard as a "user-perceived" character.
+        // `å` is a single grapheme, but it is composed of two characters (`a` and `̊`).
+        //
+        // `graphemes` returns an iterator over the graphemes in the input `s`. `true` specifies that
+        // we want to use the extended grapheme definition set, the recommended one.
+        let is_too_long = s.graphemes(true).count() > 256;
+
+        // Iterate over all characters in the input `s` to check if any of them matches one of the
+        // characters in the forbidden array.
+        let forbidden_characters = ['/', '(', ')', '"', '<', '>', '\\', '{', '}'];
+        let contains_forbidden_chracters = s
+            .chars()
+            .any(|g| forbidden_characters.contains(&g));
+
+        if is_empty_or_whitespace || is_too_long || contains_forbidden_chracters {
+            // Is this really an UNRECOVERABLE error?
+            // A panic! isn't comparable to exceptions in many other languages.
+            Err(format!("{} is not a valid subscriber name", s))
+        } else {
+            Ok(Self(s))
+        }
+    }
+}
+
+impl AsRef<str> for SubscriberName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::domain::SubscriberName;
+    use claim::{assert_err, assert_ok};
+
+    #[test]
+    fn a_256_grapheme_long_name_is_valid() {
+        let name = "ё".repeat(256);
+        assert_ok!(SubscriberName::parse(name));
+    }
+
+    #[test]
+    fn a_name_longer_than_256_graphemes_is_rejected() {
+        let name = "a".repeat(257);
+        assert_err!(SubscriberName::parse(name));
+    }
+
+    #[test]
+    fn whitespace_only_names_are_rejected() {
+        let name = " ".to_string();
+        assert_err!(SubscriberName::parse(name));
+    }
+
+    #[test]
+    fn empty_string_is_rejected() {
+        let name = "".to_string();
+        assert_err!(SubscriberName::parse(name));
+    }
+
+    #[test]
+    fn names_containing_an_invalid_character_are_rejected() {
+        for name in &['/', '(', ')', '"', '<', '>', '\\', '{', '}'] {
+            let name = name.to_string();
+            assert_err!(SubscriberName::parse(name));
+        }
+    }
+
+    #[test]
+    fn a_valid_name_is_parsed_successfully() {
+        let name = "Ursula Le Guin".to_string();
+        assert_ok!(SubscriberName::parse(name));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod configuration;
+pub mod domain;
 pub mod routes;
 pub mod startup;
 pub mod telemetry;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,7 @@
-mod routes;
-
 use zero2prod::configuration::get_configuration;
 use zero2prod::startup::run;
 use zero2prod::telemetry::{get_subscriber, init_subscriber};
 use secrecy::ExposeSecret;
-// use sqlx::PgPool;
 use sqlx::postgres::PgPoolOptions;
 use std::net::TcpListener;
 

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -1,13 +1,26 @@
 use actix_web::{web, HttpResponse};
 use sqlx::PgPool;
+use std::convert::{TryFrom, TryInto};
 use chrono::Utc;
 use uuid::Uuid;
 use tracing::Instrument;
+use unicode_segmentation::UnicodeSegmentation;
+use crate::domain::{NewSubscriber, SubscriberName, SubscriberEmail};
 
 #[derive(serde::Deserialize)]
 pub struct FormData {
     email: String,
     name: String
+}
+
+impl TryFrom<FormData> for NewSubscriber {
+    type Error = String;
+
+    fn try_from(value: FormData) -> Result<Self, Self::Error> {
+        let name = SubscriberName::parse(value.name)?;
+        let email = SubscriberEmail::parse(value.email)?;
+        Ok(Self { email, name })
+    }
 }
 
 #[tracing::instrument(
@@ -19,15 +32,24 @@ pub struct FormData {
     )
 )]
 
-// web::Data is an extractor, but what's it extracting a PgConnection from?
+// web::Data is an extractor, but what is it extracting a PgConnection from?
 // When a new request comes in, actix computes the TypeId of the type specified in the signature,
 // checks if there is a record corresponding to it in the type-map (actix handles this), and if
 // there is it casts the retrieved Any value to the specified type.
 //
 // Other languages refer to this as a dependency injection.
-pub async fn subscribe(form: web::Form<FormData>, pool: web::Data<PgPool>) -> HttpResponse {
-    match insert_subscriber(&pool, &form).await
-    {
+pub async fn subscribe(
+    form: web::Form<FormData>,
+    pool: web::Data<PgPool>
+) -> HttpResponse {
+
+    //  `web::Form` is a wrapper around `FormData` `form.0` gives us access to the underlying
+    //  `FormData`
+    let new_subscriber = match form.0.try_into() {
+        Ok(form) => form,
+        Err(_) => return HttpResponse::BadRequest().finish(),
+    };
+    match insert_subscriber(&pool, &new_subscriber).await {
         Ok(_) => HttpResponse::Ok().finish(),
         Err(_) => HttpResponse::InternalServerError().finish()
     }
@@ -35,11 +57,12 @@ pub async fn subscribe(form: web::Form<FormData>, pool: web::Data<PgPool>) -> Ht
 
 #[tracing::instrument(
     name = "Saving new subscriber details in the database",
-    skip(form, pool)
+    skip(new_subscriber, pool)
 )]
 pub async fn insert_subscriber(
     pool: &PgPool,
-    form: &FormData,
+    new_subscriber: &NewSubscriber,
+    // form: &FormData,
 ) -> Result<(), sqlx::Error> {
     sqlx::query!(
         r#"
@@ -47,8 +70,8 @@ pub async fn insert_subscriber(
         VALUES ($1, $2, $3, $4)
         "#,
         Uuid::new_v4(),
-        form.email,
-        form.name,
+        new_subscriber.email.as_ref(),
+        new_subscriber.name.as_ref(),
         Utc::now()
     )
     // We use `get_ref` to get an immutable reference to the `PgConnection`

--- a/tests/health_check.rs
+++ b/tests/health_check.rs
@@ -93,6 +93,37 @@ async fn health_check_works() {
 }
 
 #[tokio::test]
+async fn subscribe_returns_a_400_when_fields_are_present_but_invalid() {
+    // Arrange
+    let app = spawn_app().await;
+    let client = reqwest::Client::new();
+    let test_case = vec![
+        ("name=&email=ursula_le_guin%40gmail.com", "empty name"),
+        ("name=Ursula&email=", "empty email"),
+        ("name=&email=definitely-not-an-email", "invalid email"),
+    ];
+
+    for (body, description) in test_case {
+        // Act
+        let response = client
+            .post(&format!("{}/subscriptions", &app.address))
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .body(body)
+            .send()
+            .await
+            .expect("Failed to execute request.");
+
+        // Assert
+        assert_eq!(
+            400,
+            response.status().as_u16(),
+            "The API did not return a 400 Bad Request when the payload was {}.",
+            description
+        );
+    }
+}
+
+#[tokio::test]
 async fn subscribe_returns_a_200_for_valid_form_data() {
     let app = spawn_app().await;
     let connection = app.db_pool;


### PR DESCRIPTION
This chapter focused on "Parse, don't validate", and making sure our tests were solid. We covered property-based testing, and making sure we enforce correctness through types (focusing on local code rather than global).